### PR TITLE
Provide competitive .NET Core implementation

### DIFF
--- a/TrustpilotAesChallenge/CSharp/CSharp.csproj
+++ b/TrustpilotAesChallenge/CSharp/CSharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/TrustpilotAesChallenge/CSharp/Program.cs
+++ b/TrustpilotAesChallenge/CSharp/Program.cs
@@ -1,27 +1,28 @@
-﻿using System;
-using System.Runtime;
-using System.IO;
+using System;
 using System.Security.Cryptography;
-using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace CSharp
 {
     class Program
     {
-        static AesManaged aes = new AesManaged { BlockSize = 128, KeySize = 256, Padding = PaddingMode.Zeros };       
+        private static readonly AesManaged aes = new AesManaged { BlockSize = 128, KeySize = 256, Padding = PaddingMode.Zeros };       
+        private static ReadOnlySpan<byte> trust => 
+            new byte[] {0x74, 0x72, 0x75, 0x73, 0x74};
 
-        static string Decrypt(byte[] cipherText, byte[] key, byte[] iv)
+        private static bool ContainsTrust(byte[] plaintext) =>
+            plaintext.AsSpan().IndexOf(trust) >= 0;
+
+        private static void Decrypt(byte[] cipherText, byte[] plaintext, byte[] key, byte[] iv)
         {
             var decryptor = aes.CreateDecryptor(key, iv);
-            using (var ms = new MemoryStream(cipherText))
-            using (var cs = new CryptoStream(ms, decryptor, CryptoStreamMode.Read))
-            using (var sr = new StreamReader(cs))
-                return sr.ReadToEnd();
+            decryptor.TransformBlock(cipherText, 0, cipherText.Length, plaintext, 0);
         }
 
         static void Main(string[] args)
         {
             var cipherText = Convert.FromBase64String("yptyoDdVBdQtGhgoePppYHnWyugGmy0j81sf3zBeUXEO/LYRw+2XmVa0/v6YiSy9Kj8gMn/gNu2I7dPmfgSEHPUDJpNpiOWmmW1/jw/Pt29Are5tumWmnfkazcAb23xe7B4ruPZVxUEhfn/IrZPNZdr4cQNrHNgEv2ts8gVFuOBU+p792UPy8/mEIhW5ECppxGIb7Yrpg4w7IYNeFtX5d9W4W1t2e+6PcdcjkBK4a8y1cjEtuQ07RpPChOvLcSzlB/Bg7UKntzorRsn+y/d72qD2QxRzcXgbynCNalF7zaT6pEnwKB4i05fTQw6nB7SU1w2/EvCGlfiyR2Ia08mA0GikqegYA6xG/EAGs3ZJ0aQUGt0YZz0P7uBsQKdmCg7jzzEMHyGZDNGTj0F2dOFHLSOTT2/GGSht8eD/Ae7u/xnJj0bGgAKMtNttGFlNyvKpt2vDDT3Orfk6Jk/rD4CIz6O/Tnt0NkJLucHtIyvBYGtQR4+mhbfUELkczeDSxTXGDLaiU3de6tPaa0/vjzizoUbNFdfkIly/HWINdHoO83E=");
+            var plaintext = new byte[cipherText.Length];
             var iv = Convert.FromBase64String("DkBbcmQo1QH+ed1wTyBynA==");
             var key = new byte[32];
 
@@ -39,9 +40,9 @@ namespace CSharp
                                     key[4] = e;
                                     key[5] = f;
 
-                                    var clearText = Decrypt(cipherText, key, iv);                                    
-                                    if (clearText.Contains("trust"))
-                                        Console.WriteLine($"{a} {b} {c} {d} {e} {f}\n{clearText}");
+                                    Decrypt(cipherText, plaintext, key, iv);                                    
+                                    if (ContainsTrust(plaintext))
+                                        Console.WriteLine($"{a} {b} {c} {d} {e} {f}\n{Encoding.ASCII.GetString(plaintext)}");
                                 }
         }
     }


### PR DESCRIPTION
So I stumbled over your repository and the original challenge from Trustpilot. I really like your approach to the challenge!
I do however propose a more competitive implementation in this PR.

Changes include:

* Avoid the use of allocation heavy `Stream`s and `string`s on the hot path of the `Main` method and allow the re-use of a single plaintext buffer
* Avoid the encoding of every decrypted ciphertext by searching for the ASCII values of "trust" in the plaintext buffer
* Only encode the plaintext buffer, once a possible solution was found

I'll let you discover the performance difference yourself :)